### PR TITLE
[3.1.2] - 2023-12-27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # CHANGELOG
 
+## [3.1.2] - 2023-12-27
+### Changed
+- README.md: Corrected link to NAPALM; Minimal changes to other text.
+- pyproject.toml: Bumped python to 3.11, napalm to 4.1.0
+- Removing ciscoconfparse (1.9.41)
+- Removing deprecated (1.2.14)
+- Removing dnspython (2.4.2)
+- Removing hier-config (2.2.2)
+- Removing loguru (0.7.2)
+- Removing passlib (1.7.4)
+- Removing tenacity (8.2.3)
+- Installing ttp (0.9.5)
+- Updating netmiko (3.4.0 -> 4.3.0): Downloading... 80%
+- Installing netutils (1.6.0): Installing...
+- Installing ttp-templates (0.3.5)
+- Updating netmiko (3.4.0 -> 4.3.0)
+- Installing netutils (1.6.0)
+- Installing ttp-templates (0.3.5)
+- Installing typing-extensions (4.9.0)
+- Updating napalm (3.4.1 -> 4.1.0)
+
+
 ## [3.1.1] - 2023-12-26
 ### Changed
 - Removing anyio (3.7.1)

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ A Python script to capture the running-config of Cisco Routers and Switches.
 ## Getting Started
 
 ### About This Code
-This script was originally written in Python2 and relied on [Exscript](https://github.com/knipknap/exscript/) to handle all the 'heavy lifting' of communicating with the router.
+This script was originally written in Python2 and relied on [Exscript](https://github.com/knipknap/exscript/) to handle the 'heavy lifting' of communicating with the router.
 
 However, it appears that Exscript went the way of Python2 and is no longer supported.
 
-In conjunction with updating this code to work with Python3, I've also selected [NAPALM](https://github.com/ktbyers/napalm) to replace the functionality that Exscript once provided.
+In conjunction with updating this code to work with Python3, I've selected [NAPALM](https://github.com/napalm-automation/napalm) to replace the functionality that Exscript once provided.
 
 #### Requirements
 1. This application is hard-coded to use the SSH2 protocol; If SSH v2 is not enabled on your router(s), you will need to add `ip ssh version 2` to your Cisco router(s) configuration and any associated access-list changes.
 2. A valid username/password.
 3. A text file containing hostnames or IP Addresses of your routers/switches, one entry per line.
-4. Environment variables for logging (LOG_LEVEL, LOG_PATH, LOG_PREFIX) OR you can hard-code the log_dict{} variables in config.py.
+4. Environment variables for logging (LOG_LEVEL, LOG_PATH, LOG_PREFIX) OR you can hard-code the log_dict{} variables in the configuration section.
 
 #### Assumptions
 1. This application was written for use on Cisco IOS devices and cannot be guaranteed to work on other makes/model routers.

--- a/download_router_config/download_router_config.py
+++ b/download_router_config/download_router_config.py
@@ -21,12 +21,12 @@ class Config:
         """Application Variables."""
         self.app_dict = {
             "author": "Aaron Melton <aaron@aaronmelton.com>",
-            "date": "2023-12-26",
+            "date": "2023-12-27",
             "desc": "A Python script to capture the running-config of Cisco routers and switches.",
             "name": "download_router_config.py",
             "title": "Download Router Config",
             "url": "https://github.com/aaronmelton/DownloadRouterConfig",
-            "version": "3.1.1",
+            "version": "3.1.2",
         }
 
         # Logging Variables

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,11 +13,7 @@ files = [
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.11\""}
-wrapt = [
-    {version = ">=1.11,<2", markers = "python_version < \"3.11\""},
-    {version = ">=1.14,<2", markers = "python_version >= \"3.11\""},
-]
+wrapt = {version = ">=1.14,<2", markers = "python_version >= \"3.11\""}
 
 [[package]]
 name = "bandit"
@@ -108,7 +104,6 @@ click = ">=8.0.0"
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
@@ -291,25 +286,6 @@ files = [
 ]
 
 [[package]]
-name = "ciscoconfparse"
-version = "1.9.41"
-description = "Parse, Audit, Query, Build, and Modify Cisco IOS-style and JunOS-style configs"
-optional = false
-python-versions = ">=3.8,<4.0.0"
-files = [
-    {file = "ciscoconfparse-1.9.41-py3-none-any.whl", hash = "sha256:4809a4e719299e93168568dcffb5211b62284422db24e0fb0cdc6dd6d303610e"},
-    {file = "ciscoconfparse-1.9.41.tar.gz", hash = "sha256:2277e1466efda45600ac03f33c2285b033458e57fa502c3ea07bfe56bcc06f30"},
-]
-
-[package.dependencies]
-deprecated = ">=1.2.14"
-dnspython = ">=2.4.2,<3.0.0"
-hier_config = ">=2.2.2"
-loguru = "0.7.2"
-passlib = ">=1.7.4,<2.0.0"
-toml = ">=0.10.2"
-
-[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -442,23 +418,6 @@ test = ["pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
-name = "deprecated"
-version = "1.2.14"
-description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-files = [
-    {file = "Deprecated-1.2.14-py2.py3-none-any.whl", hash = "sha256:6fac8b097794a90302bdbb17b9b815e732d3c4720583ff1b198499d78470466c"},
-    {file = "Deprecated-1.2.14.tar.gz", hash = "sha256:e5323eb936458dccc2582dc6f9c322c852a775a27065ff2b0c4970b9d53d01b3"},
-]
-
-[package.dependencies]
-wrapt = ">=1.10,<2"
-
-[package.extras]
-dev = ["PyTest", "PyTest-Cov", "bump2version (<1)", "sphinx (<2)", "tox"]
-
-[[package]]
 name = "dill"
 version = "0.3.7"
 description = "serialize all of Python"
@@ -471,39 +430,6 @@ files = [
 
 [package.extras]
 graph = ["objgraph (>=1.7.2)"]
-
-[[package]]
-name = "dnspython"
-version = "2.4.2"
-description = "DNS toolkit"
-optional = false
-python-versions = ">=3.8,<4.0"
-files = [
-    {file = "dnspython-2.4.2-py3-none-any.whl", hash = "sha256:57c6fbaaeaaf39c891292012060beb141791735dbb4004798328fc2c467402d8"},
-    {file = "dnspython-2.4.2.tar.gz", hash = "sha256:8dcfae8c7460a2f84b4072e26f1c9f4101ca20c071649cb7c34e8b6a93d58984"},
-]
-
-[package.extras]
-dnssec = ["cryptography (>=2.6,<42.0)"]
-doh = ["h2 (>=4.1.0)", "httpcore (>=0.17.3)", "httpx (>=0.24.1)"]
-doq = ["aioquic (>=0.9.20)"]
-idna = ["idna (>=2.1,<4.0)"]
-trio = ["trio (>=0.14,<0.23)"]
-wmi = ["wmi (>=1.5.1,<2.0.0)"]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.2.0"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
-    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "flake8"
@@ -578,20 +504,6 @@ gitdb = ">=4.0.1,<5"
 
 [package.extras]
 test = ["black", "coverage[toml]", "ddt (>=1.1.1,!=1.4.3)", "mock", "mypy", "pre-commit", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-sugar"]
-
-[[package]]
-name = "hier-config"
-version = "2.2.2"
-description = "A network configuration comparison tool, used to build remediation configurations."
-optional = false
-python-versions = ">=3.8,<4.0"
-files = [
-    {file = "hier-config-2.2.2.tar.gz", hash = "sha256:a394f6783de2f93f641cbb3a819da931585281fed81cfc7adc71268eb340c632"},
-    {file = "hier_config-2.2.2-py3-none-any.whl", hash = "sha256:cb5af71a765cb92d7478cb3695291220d9680696fbc77a790089ec8ca1f743cd"},
-]
-
-[package.dependencies]
-PyYAML = ">=5.4"
 
 [[package]]
 name = "idna"
@@ -715,24 +627,6 @@ files = [
     {file = "lazy_object_proxy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:a899b10e17743683b293a729d3a11f2f399e8a90c73b089e29f5d0fe3509f0dd"},
     {file = "lazy_object_proxy-1.10.0-pp310.pp311.pp312.pp38.pp39-none-any.whl", hash = "sha256:80fa48bd89c8f2f456fc0765c11c23bf5af827febacd2f523ca5bc1893fcc09d"},
 ]
-
-[[package]]
-name = "loguru"
-version = "0.7.2"
-description = "Python logging made (stupidly) simple"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "loguru-0.7.2-py3-none-any.whl", hash = "sha256:003d71e3d3ed35f0f8984898359d65b79e5b21943f78af86aa5491210429b8eb"},
-    {file = "loguru-0.7.2.tar.gz", hash = "sha256:e671a53522515f34fd406340ee968cb9ecafbc4b36c679da03c18fd8d0bd51ac"},
-]
-
-[package.dependencies]
-colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
-win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
-
-[package.extras]
-dev = ["Sphinx (==7.2.5)", "colorama (==0.4.5)", "colorama (==0.4.6)", "exceptiongroup (==1.1.3)", "freezegun (==1.1.0)", "freezegun (==1.2.2)", "mypy (==v0.910)", "mypy (==v0.971)", "mypy (==v1.4.1)", "mypy (==v1.5.1)", "pre-commit (==3.4.0)", "pytest (==6.1.2)", "pytest (==7.4.0)", "pytest-cov (==2.12.1)", "pytest-cov (==4.1.0)", "pytest-mypy-plugins (==1.9.3)", "pytest-mypy-plugins (==3.0.0)", "sphinx-autobuild (==2021.3.14)", "sphinx-rtd-theme (==1.3.0)", "tox (==3.27.1)", "tox (==4.11.0)"]
 
 [[package]]
 name = "lxml"
@@ -960,25 +854,25 @@ files = [
 
 [[package]]
 name = "napalm"
-version = "3.4.1"
+version = "4.1.0"
 description = "Network Automation and Programmability Abstraction Layer with Multivendor support"
 optional = false
 python-versions = "*"
 files = [
-    {file = "napalm-3.4.1-py2.py3-none-any.whl", hash = "sha256:c1ab88c8a7474d3657fed69afb2d94cef27f5d57bb1973ecba8def39a1990839"},
-    {file = "napalm-3.4.1.tar.gz", hash = "sha256:9a9673f79a1c257a23af62675689d0d34a8c7b1a98702f5c1aab841bf1a829cd"},
+    {file = "napalm-4.1.0-py2.py3-none-any.whl", hash = "sha256:14a5b7759a0247a26fff2c444b1cfc150a08224de8addf4076c384845285bf5b"},
+    {file = "napalm-4.1.0.tar.gz", hash = "sha256:3b3e18efd556861c056ba509eb46f5ffc9e3e6c42db399fa76b6ea9af272c17a"},
 ]
 
 [package.dependencies]
 cffi = ">=1.11.3"
-ciscoconfparse = "*"
 future = "*"
 jinja2 = "*"
 junos-eznc = ">=2.6.3"
 lxml = ">=4.3.0"
 ncclient = "*"
 netaddr = "*"
-netmiko = ">=3.3.0,<4.0.0"
+netmiko = ">=4.1.0"
+netutils = ">=1.0.0"
 paramiko = ">=2.6.0"
 pyeapi = ">=0.8.2"
 pyYAML = "*"
@@ -986,6 +880,9 @@ requests = ">=2.7.0"
 scp = "*"
 setuptools = ">=38.4.0"
 textfsm = "*"
+ttp = "*"
+ttp-templates = "*"
+typing-extensions = ">=4.3.0"
 
 [[package]]
 name = "ncclient"
@@ -1016,25 +913,36 @@ files = [
 
 [[package]]
 name = "netmiko"
-version = "3.4.0"
-description = "Multi-vendor library to simplify Paramiko SSH connections to network devices"
+version = "4.3.0"
+description = "Multi-vendor library to simplify legacy CLI connections to network devices"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "netmiko-3.4.0-py3-none-any.whl", hash = "sha256:b66f25717db3609878f83c85604349dd40a0ab494d8eafd817dcde8388131136"},
-    {file = "netmiko-3.4.0.tar.gz", hash = "sha256:acadb9dd97864ee848e2032f1f0e301c7b31e7a4153757d98f5c8ba1b9614993"},
+    {file = "netmiko-4.3.0-py3-none-any.whl", hash = "sha256:a873b186e0b61be4a2100eda51e996d917ceddce195b734346b686757e61d324"},
+    {file = "netmiko-4.3.0.tar.gz", hash = "sha256:da90f6efdf33b4140eb6cd7f2272773c2ce144fa74ac34d5ecac1b4d4607f1fb"},
 ]
 
 [package.dependencies]
-ntc-templates = "*"
-paramiko = ">=2.6.0"
-pyserial = "*"
-scp = ">=0.13.2"
-setuptools = ">=38.4.0"
-tenacity = "*"
+ntc-templates = ">=2.0.0"
+paramiko = ">=2.9.5"
+pyserial = ">=3.3"
+pyyaml = ">=5.3"
+scp = ">=0.13.6"
+textfsm = ">=1.1.3"
+
+[[package]]
+name = "netutils"
+version = "1.6.0"
+description = "Common helper functions useful in network automation."
+optional = false
+python-versions = ">=3.8,<4.0"
+files = [
+    {file = "netutils-1.6.0-py3-none-any.whl", hash = "sha256:e755e6141d0968f1deeb61693a4023f4f5fe1f0dde25d94ac1008f8191d8d237"},
+    {file = "netutils-1.6.0.tar.gz", hash = "sha256:bd2fa691e172fe9d5c9e6fc5e2593316eb7fd2c36450454894ed13b274763d70"},
+]
 
 [package.extras]
-test = ["pytest (>=5.1.2)", "pyyaml (>=5.1.2)"]
+optionals = ["jsonschema (>=4.17.3,<5.0.0)", "napalm (>=4.0.0,<5.0.0)"]
 
 [[package]]
 name = "ntc-templates"
@@ -1081,23 +989,6 @@ pynacl = ">=1.5"
 all = ["gssapi (>=1.4.1)", "invoke (>=2.0)", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8)"]
 gssapi = ["gssapi (>=1.4.1)", "pyasn1 (>=0.1.7)", "pywin32 (>=2.1.8)"]
 invoke = ["invoke (>=2.0)"]
-
-[[package]]
-name = "passlib"
-version = "1.7.4"
-description = "comprehensive password hashing framework supporting over 30 schemes"
-optional = false
-python-versions = "*"
-files = [
-    {file = "passlib-1.7.4-py2.py3-none-any.whl", hash = "sha256:aa6bca462b8d8bda89c70b382f0c298a20b5560af6cbfa2dce410c0a2fb669f1"},
-    {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
-]
-
-[package.extras]
-argon2 = ["argon2-cffi (>=18.2.0)"]
-bcrypt = ["bcrypt (>=3.1.0)"]
-build-docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)"]
-totp = ["cryptography"]
 
 [[package]]
 name = "pathspec"
@@ -1257,14 +1148,10 @@ files = [
 [package.dependencies]
 astroid = ">=2.15.8,<=2.17.0-dev0"
 colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
-dill = [
-    {version = ">=0.2", markers = "python_version < \"3.11\""},
-    {version = ">=0.3.6", markers = "python_version >= \"3.11\""},
-]
+dill = {version = ">=0.3.6", markers = "python_version >= \"3.11\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.8"
 platformdirs = ">=2.2.0"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 tomlkit = ">=0.10.1"
 
 [package.extras]
@@ -1338,11 +1225,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -1526,20 +1411,6 @@ files = [
 pbr = ">=2.0.0,<2.1.0 || >2.1.0"
 
 [[package]]
-name = "tenacity"
-version = "8.2.3"
-description = "Retry code until it succeeds"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "tenacity-8.2.3-py3-none-any.whl", hash = "sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c"},
-    {file = "tenacity-8.2.3.tar.gz", hash = "sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a"},
-]
-
-[package.extras]
-doc = ["reno", "sphinx", "tornado (>=4.5)"]
-
-[[package]]
 name = "textfsm"
 version = "1.1.3"
 description = "Python module for parsing semi-structured text into python tables."
@@ -1606,6 +1477,38 @@ diagrams = ["pygraphviz"]
 test = ["pytest"]
 
 [[package]]
+name = "ttp"
+version = "0.9.5"
+description = "Template Text Parser"
+optional = false
+python-versions = ">=2.7,<4.0"
+files = [
+    {file = "ttp-0.9.5-py2.py3-none-any.whl", hash = "sha256:2c9fcf560b3f696e9fdd3554dc8e4622cbb10cac1d4fca13a7cf608c4a7fd137"},
+    {file = "ttp-0.9.5.tar.gz", hash = "sha256:234414f4d3039d2d1cde09993f89f8db1b34d447f76c6a402555cefac2e59c4e"},
+]
+
+[package.extras]
+docs = ["Sphinx (==4.3.0)", "readthedocs-sphinx-search (==0.1.1)", "sphinx_rtd_theme (==1.0.0)", "sphinxcontrib-applehelp (==1.0.1)", "sphinxcontrib-devhelp (==1.0.1)", "sphinxcontrib-htmlhelp (==2.0.0)", "sphinxcontrib-jsmath (==1.0.1)", "sphinxcontrib-napoleon (==0.7)", "sphinxcontrib-qthelp (==1.0.2)", "sphinxcontrib-serializinghtml (==1.1.5)", "sphinxcontrib-spelling (==7.2.1)"]
+full = ["cerberus (>=1.3.0,<1.4.0)", "deepdiff (>=5.8.0,<5.9.0)", "jinja2 (>=3.0.0,<3.1.0)", "n2g (>=0.2.0,<0.3.0)", "openpyxl (>=3.0.0,<3.1.0)", "pyyaml (==6.0)", "tabulate (>=0.8.0,<0.9.0)", "ttp_templates (<1.0.0)", "yangson (>=1.4.0,<1.5.0)"]
+
+[[package]]
+name = "ttp-templates"
+version = "0.3.5"
+description = "Template Text Parser Templates collections"
+optional = false
+python-versions = ">=3.6,<4.0"
+files = [
+    {file = "ttp_templates-0.3.5-py3-none-any.whl", hash = "sha256:4985a68640468127a0e31021672039cd88a8b9c3dd9289cad67839209cddaf30"},
+    {file = "ttp_templates-0.3.5.tar.gz", hash = "sha256:e59870d4f65bd4aaf89178dc9065a7db8b80a23d5d79b5d6ffd041312d5ec5a6"},
+]
+
+[package.dependencies]
+ttp = ">=0.6.0"
+
+[package.extras]
+docs = ["mkdocs (==1.2.4)", "mkdocs-material (==7.2.2)", "mkdocs-material-extensions (==1.0.1)", "mkdocstrings[python] (>=0.18.0,<0.19.0)", "pygments (==2.11)", "pymdown-extensions (==9.3)"]
+
+[[package]]
 name = "typing-extensions"
 version = "4.9.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
@@ -1631,20 +1534,6 @@ files = [
 brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
-
-[[package]]
-name = "win32-setctime"
-version = "1.1.0"
-description = "A small Python utility to set file creation time on Windows"
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
-    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
-]
-
-[package.extras]
-dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 
 [[package]]
 name = "wrapt"
@@ -1741,5 +1630,5 @@ pyyaml = "*"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.10"
-content-hash = "ec63a2e6c78ccf23757ee54f1ce8ce307a62d084bc8dad48e2e714e8a23a7d59"
+python-versions = "^3.11"
+content-hash = "f7b3181317116266aede4d23ffe796b158029e756f2fb1bfac80b565e3b1982b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "download_router_config"
-version = "3.1.0"
+version = "3.1.2"
 description = "A Python script to capture the running-config of Cisco Routers and Switches."
 authors = ["Aaron Melton <aaron@aaronmelton.com>"]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 progress = "^1.6"
-napalm = "^3.3.1"
+napalm = "^4.1.0"
 
 [tool.poetry.dev-dependencies]
 bandit = "^1.7.4"


### PR DESCRIPTION
## [3.1.2] - 2023-12-27
### Changed
- README.md: Corrected link to NAPALM; Minimal changes to other text.
- pyproject.toml: Bumped python to 3.11, napalm to 4.1.0
- Removing ciscoconfparse (1.9.41)
- Removing deprecated (1.2.14)
- Removing dnspython (2.4.2)
- Removing hier-config (2.2.2)
- Removing loguru (0.7.2)
- Removing passlib (1.7.4)
- Removing tenacity (8.2.3)
- Installing ttp (0.9.5)
- Updating netmiko (3.4.0 -> 4.3.0): Downloading... 80%
- Installing netutils (1.6.0): Installing...
- Installing ttp-templates (0.3.5)
- Updating netmiko (3.4.0 -> 4.3.0)
- Installing netutils (1.6.0)
- Installing ttp-templates (0.3.5)
- Installing typing-extensions (4.9.0)
- Updating napalm (3.4.1 -> 4.1.0)
