### PR TITLE
[3.1.3] - 2023-12-27

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/*.log*
+**/*.tar.gz
+**/*.txt
+**/.DS_Store
+**/.coverage
+**/.pytest_cache
+**/__pycache__/
+**/bin/
+**/include/
+**/lib/
+**/lib64
+**/run*.sh
+.env
+.git/
+.gitignore
+.gitlab-ci.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## [3.1.3] - 2023-12-27
+### Added
+- .dockerignore: We should probably have one of these if we're using Docker.
+### Changed
+- Dockerfile: Bumped Python version from 3.10 to 3.11.
+### Fixed
+- README.md: Fixed instructions for using a Docker image.  (Lacked drive
+  mapping between local and container directories.)
+
+
 ## [3.1.2] - 2023-12-27
 ### Changed
 - README.md: Corrected link to NAPALM; Minimal changes to other text.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VER=3.10
+ARG PYTHON_VER=3.11
 ARG REPO_NAME=download_router_config
 
 ##################

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In conjunction with updating this code to work with Python3, I've selected [NAPA
 1. This application is hard-coded to use the SSH2 protocol; If SSH v2 is not enabled on your router(s), you will need to add `ip ssh version 2` to your Cisco router(s) configuration and any associated access-list changes.
 2. A valid username/password.
 3. A text file containing hostnames or IP Addresses of your routers/switches, one entry per line.
-4. Environment variables for logging (LOG_LEVEL, LOG_PATH, LOG_PREFIX) OR you can hard-code the log_dict{} variables in the configuration section.
+4. Environment variables for logging (LOG_LEVEL, LOG_PATH) OR you can hard-code the log_dict{} variables in the configuration section.
 
 #### Assumptions
 1. This application was written for use on Cisco IOS devices and cannot be guaranteed to work on other makes/model routers.
@@ -46,7 +46,7 @@ Use `--backup_to <path>` to specify where to save config files.
 `docker build -t download_router_config .`
 
 * To run the script:
-`docker run -it -e LOG_LEVEL=DEBUG -e LOG_PATH=/tmp/ --rm download_router_config:latest --device_list switches.txt --backup_to /tmp/`
+`docker run -v `local_directory`:`container_directory` -it -e LOG_LEVEL=DEBUG -e LOG_PATH=/tmp/ --rm download_router_config:latest --device_list /`container_directory`/switches.txt --backup_to /`container_directory`/`
 
 Replace the values for LOG_LEVEL, LOG_PATH and CLI arguments (device_list, backup_to) to suit your needs.
 

--- a/download_router_config/download_router_config.py
+++ b/download_router_config/download_router_config.py
@@ -26,7 +26,7 @@ class Config:
             "name": "download_router_config.py",
             "title": "Download Router Config",
             "url": "https://github.com/aaronmelton/DownloadRouterConfig",
-            "version": "3.1.2",
+            "version": "3.1.3",
         }
 
         # Logging Variables
@@ -91,8 +91,8 @@ def main():  # pylint: disable=broad-except,too-many-locals,too-many-statements
         ###
         backup_to = vars(args)["backup_to"]
     else:
-        logger.warning("--> Backup directory not provided; Assuming current working directory.")
-        backup_to = os.getcwd()
+        backup_to = f"{os.getcwd()}/"
+        logger.warning(f"--> Backup directory not provided; Backing up to {backup_to}...")
 
     logger.info(f"""--> Attempting to open file '{vars(args)["device_list"]}'...""")
     with open(vars(args)["device_list"], "r", encoding="utf-8") as input_file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "download_router_config"
-version = "3.1.2"
+version = "3.1.3"
 description = "A Python script to capture the running-config of Cisco Routers and Switches."
 authors = ["Aaron Melton <aaron@aaronmelton.com>"]
 


### PR DESCRIPTION
## [3.1.3] - 2023-12-27
### Added
- .dockerignore: We should probably have one of these if we're using Docker.
### Changed
- Dockerfile: Bumped Python version from 3.10 to 3.11.
### Fixed
- README.md: Fixed instructions for using a Docker image.  (Lacked drive
mapping between local and container directories.)
